### PR TITLE
ci: fix PyPI release workflow

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -59,22 +59,3 @@ jobs:
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_NAME: ${{ secrets.NETLIFY_SITE_NAME }}
-
-  release-pypi:
-    name: "Release to PyPI"
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.workflow_run.conclusion == 'success'
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-      - name: "Build Package"
-        run: |
-          python -m pip install build wheel
-          python -m build --sdist --wheel
-      - name: "Deploy to PyPI"
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -35,3 +35,23 @@ jobs:
       - name: Test
         run: |
           uv run pytest
+
+  release-pypi:
+    name: "Release to PyPI"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs: [test]
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: "Build Package"
+        run: |
+          python -m pip install build wheel
+          python -m build --sdist --wheel
+      - name: "Deploy to PyPI"
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The workflow had been attached to the docs-build, rather than the tests workflow.