### PR TITLE
rename `gt_hyperlink` to `with_hyperlink`

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -95,7 +95,7 @@ quartodoc:
       contents:
         - fmt_pct_extra
         - gt_add_divider
-        - gt_hyperlink
+        - with_hyperlink
         - with_tooltip
 
 

--- a/gt_extras/__init__.py
+++ b/gt_extras/__init__.py
@@ -23,7 +23,7 @@ from .plotting import (
     gt_plt_bar_stack,
 )
 
-from .html import gt_hyperlink, with_tooltip
+from .html import with_hyperlink, with_tooltip
 
 from .formatting import fmt_pct_extra
 
@@ -52,7 +52,7 @@ __all__ = [
     "gt_plt_dumbbell",
     "gt_plt_winloss",
     "gt_plt_bar_stack",
-    "gt_hyperlink",
+    "with_hyperlink",
     "with_tooltip",
     "fmt_pct_extra",
     "img_header",

--- a/gt_extras/html.py
+++ b/gt_extras/html.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 from typing import Literal
 
-__all__ = ["gt_hyperlink", "with_tooltip"]
+__all__ = ["with_hyperlink", "with_tooltip"]
 
 
-def gt_hyperlink(text: str, url: str, new_tab: bool = True) -> int:
+def with_hyperlink(text: str, url: str, new_tab: bool = True) -> int:
     """
     Create HTML hyperlinks for use in `GT` cells.
 
-    The `gt_hyperlink()` function creates properly formatted HTML hyperlink elements that can be
+    The `with_hyperlink()` function creates properly formatted HTML hyperlink elements that can be
     used within table cells.
 
     Parameters
@@ -52,12 +52,12 @@ def gt_hyperlink(text: str, url: str, new_tab: bool = True) -> int:
     )
 
     df["Package"] = [
-        gte.gt_hyperlink(name, url)
+        gte.with_hyperlink(name, url)
         for name, url in zip(df["name"], df["url"])
     ]
 
     df["Github Stars"] = [
-        gte.gt_hyperlink(github_stars, repo_url, new_tab=False)
+        gte.with_hyperlink(github_stars, repo_url, new_tab=False)
         for github_stars, repo_url in zip(df["github_stars"], df["repo_url"])
     ]
 

--- a/gt_extras/tests/test_html.py
+++ b/gt_extras/tests/test_html.py
@@ -1,40 +1,40 @@
 import pytest
 import pandas as pd
 from great_tables import GT
-from gt_extras.html import gt_hyperlink, with_tooltip
+from gt_extras.html import with_hyperlink, with_tooltip
 
 
-def test_gt_hyperlink_basic():
-    result = gt_hyperlink("Google", "https://google.com")
+def test_with_hyperlink_basic():
+    result = with_hyperlink("Google", "https://google.com")
     expected = '<a href="https://google.com" target="_blank">Google</a>'
     assert result == expected
 
 
-def test_gt_hyperlink_new_tab_false():
-    result = gt_hyperlink("Google", "https://google.com", new_tab=False)
+def test_with_hyperlink_new_tab_false():
+    result = with_hyperlink("Google", "https://google.com", new_tab=False)
     expected = '<a href="https://google.com" target="_self">Google</a>'
     assert result == expected
 
 
-def test_gt_hyperlink_new_tab_true():
-    result = gt_hyperlink("GitHub", "https://github.com", new_tab=True)
+def test_with_hyperlink_new_tab_true():
+    result = with_hyperlink("GitHub", "https://github.com", new_tab=True)
     expected = '<a href="https://github.com" target="_blank">GitHub</a>'
     assert result == expected
 
 
-def test_gt_hyperlink_empty_text():
-    result = gt_hyperlink("", "https://example.com")
+def test_with_hyperlink_empty_text():
+    result = with_hyperlink("", "https://example.com")
     expected = '<a href="https://example.com" target="_blank"></a>'
     assert result == expected
 
 
-def test_gt_hyperlink_in_table():
+def test_with_hyperlink_in_table():
     df = pd.DataFrame(
         {
             "Name": ["Google", "GitHub"],
             "Link": [
-                gt_hyperlink("Visit Google", "https://google.com"),
-                gt_hyperlink("View GitHub", "https://github.com", new_tab=False),
+                with_hyperlink("Visit Google", "https://google.com"),
+                with_hyperlink("View GitHub", "https://github.com", new_tab=False),
             ],
         }
     )


### PR DESCRIPTION
This keeps in consistency with all `gt_*` functions taking a `GT` as input and returning a modified `GT` as output.