### PR TITLE
Minor typo in intro.qmd

### DIFF
--- a/docs/articles/intro.qmd
+++ b/docs/articles/intro.qmd
@@ -87,7 +87,7 @@ If you encounter a bug, have usage questions, or want to share ideas to make thi
 ::: {.callout-tip collapse="false"}
 ## What you might get to consider
 
-Some of the work that went into this project was featued on the [_great tables blog_](https://posit-dev.github.io/great-tables/blog/plots-in-tables/), if you choose to contribute hopefully that can give you a sense of the process!
+Some of the work that went into this project was featured on the [_great tables blog_](https://posit-dev.github.io/great-tables/blog/plots-in-tables/), if you choose to contribute hopefully that can give you a sense of the process!
 
 :::
 


### PR DESCRIPTION
# Summary

Fix minor typo in `docs/articles/intro.qmd`.

# Related GitHub Issues and PRs
None.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
