### PR TITLE
docs: Resize and rename theme examples

### DIFF
--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: Examples
 notebook-links: false
+toc: false
 ---
 
 <style>
@@ -121,60 +122,58 @@ addEventListener('resize', setTableWidths);
 
 ::::{.masonry-container}
 
-:::{.masonry-item}
+<!-- Override width in case they render slowly -->
+:::{.masonry-item style="--width: 686;"}
 {{< embed with-code.qmd#gt_plt_bar >}}
 [gt_plt_bar](./with-code.html#gt_plt_bar){.embed-hover-overlay}
 :::
 
-:::{.masonry-item}
+:::{.masonry-item style="--width: 249;"}
 {{< embed with-code.qmd#gt_plt_bar_pct >}}
 [gt_plt_bar_pct](./with-code.html#gt_plt_bar_pct){.embed-hover-overlay}
 :::
 
-:::{.masonry-item}
+:::{.masonry-item style="--width: 297;"}
 {{< embed with-code.qmd#gt_plt_bar_stack >}}
 [gt_plt_bar_stack](./with-code.html#gt_plt_bar_stack){.embed-hover-overlay}
 :::
 
-<!-- Override width on some of the slower rendering ones -->
 :::{.masonry-item style="--width: 323;"}
 {{< embed with-code.qmd#gt_plt_bullet >}}
 [gt_plt_bullet](./with-code.html#gt_plt_bullet){.embed-hover-overlay}
 :::
 
-:::{.masonry-item}
+:::{.masonry-item style="--width: 376;"}
 {{< embed with-code.qmd#gt_plt_conf_int >}}
 [gt_plt_conf_int](./with-code.html#gt_plt_conf_int){.embed-hover-overlay}
 :::
 
-<!-- Override width on some of the slower rendering ones -->
 :::{.masonry-item style="--width: 292;"}
 {{< embed with-code.qmd#gt_plt_dot >}}
 [gt_plt_dot](./with-code.html#gt_plt_dot){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 359;"}
+:::{.masonry-item style="--width: 413;"}
 {{< embed with-code.qmd#gt_plt_dumbbell >}}
 [gt_plt_dumbbell](./with-code.html#gt_plt_dumbbell){.embed-hover-overlay}
 :::
 
-:::{.masonry-item}
+:::{.masonry-item style="--width: 167;"}
 {{< embed with-code.qmd#gt_plt_winloss >}}
 [gt_plt_winloss](./with-code.html#gt_plt_winloss){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 209;"}
+:::{.masonry-item style="--width: 211;"}
 {{< embed with-code.qmd#gt_color_box >}}
 [gt_color_box](./with-code.html#gt_color_box){.embed-hover-overlay}
 :::
 
-<!-- Override width on some of the slower rendering ones -->
-:::{.masonry-item style="--width: 322;"}
+:::{.masonry-item style="--width: 347;"}
 {{< embed with-code.qmd#gt_data_color_by_group >}}
 [gt_data_color_by_group](./with-code.html#gt_data_color_by_group){.embed-hover-overlay}
 :::
 
-:::{.masonry-item}
+:::{.masonry-item style="--width: 323;"}
 {{< embed with-code.qmd#gt_highlight_cols >}}
 [gt_highlight_cols](./with-code.html#gt_highlight_cols){.embed-hover-overlay}
 :::
@@ -194,17 +193,17 @@ addEventListener('resize', setTableWidths);
 [gt_theme_538](./with-code.html#gt_theme_538){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 395;"}
+:::{.masonry-item style="--width: 359;"}
 {{< embed with-code.qmd#gt_theme_espn >}}
 [gt_theme_espn](./with-code.html#gt_theme_espn){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 417;"}
+:::{.masonry-item style="--width: 388;"}
 {{< embed with-code.qmd#gt_theme_guardian >}}
 [gt_theme_guardian](./with-code.html#gt_theme_guardian){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 334;"}
+:::{.masonry-item style="--width: 308;"}
 {{< embed with-code.qmd#gt_theme_nytimes >}}
 [gt_theme_nytimes](./with-code.html#gt_theme_nytimes){.embed-hover-overlay}
 :::
@@ -214,7 +213,7 @@ addEventListener('resize', setTableWidths);
 [gt_theme_excel](./with-code.html#gt_theme_excel){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 411;"}
+:::{.masonry-item style="--width: 378;"}
 {{< embed with-code.qmd#gt_theme_dot_matrix >}}
 [gt_theme_dot_matrix](./with-code.html#gt_theme_dot_matrix){.embed-hover-overlay}
 :::
@@ -224,7 +223,7 @@ addEventListener('resize', setTableWidths);
 [gt_theme_dark](./with-code.html#gt_theme_dark){.embed-hover-overlay}
 :::
 
-:::{.masonry-item style="--width: 488;"}
+:::{.masonry-item style="--width: 283;"}
 {{< embed with-code.qmd#gt_theme_pff >}}
 [gt_theme_pff](./with-code.html#gt_theme_pff){.embed-hover-overlay}
 :::
@@ -239,7 +238,7 @@ addEventListener('resize', setTableWidths);
 [fa_icon_repeat](./with-code.html#fa_icon_repeat){.embed-hover-overlay}
 :::
 
-:::{.masonry-item}
+:::{.masonry-item style="--width: 451;"}
 {{< embed with-code.qmd#gt_fa_rank_change >}}
 [gt_fa_rank_change](./with-code.html#gt_fa_rank_change){.embed-hover-overlay}
 :::

--- a/docs/examples/with-code.qmd
+++ b/docs/examples/with-code.qmd
@@ -386,8 +386,8 @@ airquality_mini = airquality.head(10).assign(Year=1973)
 gt = (
     GT(airquality_mini)
     .tab_header(
-        title="New York Air Quality Measurements",
-        subtitle="Daily measurements in New York City (May 1-10, 1973)",
+        title="Default Theme",
+        subtitle="New York Air Quality Measurements",
     )
     .tab_spanner(label="Time", columns=["Year", "Month", "Day"])
     .tab_spanner(
@@ -409,6 +409,8 @@ gt
 ### [gt_theme_538](https://posit-dev.github.io/gt-extras/reference/gt_theme_538.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_538
+gt = gt.tab_header(title="FiveThirtyEight Theme")
+
 gt.pipe(gte.gt_theme_538)
 ```
 {{< include ./_show-last.qmd >}}
@@ -416,6 +418,8 @@ gt.pipe(gte.gt_theme_538)
 ### [gt_theme_espn](https://posit-dev.github.io/gt-extras/reference/gt_theme_espn.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_espn
+gt = gt.tab_header(title="ESPN Theme")
+
 gt.pipe(gte.gt_theme_espn)
 ```
 {{< include ./_show-last.qmd >}}
@@ -423,6 +427,8 @@ gt.pipe(gte.gt_theme_espn)
 ### [gt_theme_guardian](https://posit-dev.github.io/gt-extras/reference/gt_theme_guardian.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_guardian
+gt = gt.tab_header(title="Guardian Theme")
+
 gt.pipe(gte.gt_theme_guardian)
 ```
 {{< include ./_show-last.qmd >}}
@@ -430,6 +436,8 @@ gt.pipe(gte.gt_theme_guardian)
 ### [gt_theme_nytimes](https://posit-dev.github.io/gt-extras/reference/gt_theme_nytimes.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_nytimes
+gt = gt.tab_header(title="NYTimes Theme")
+
 gt.pipe(gte.gt_theme_nytimes)
 ```
 {{< include ./_show-last.qmd >}}
@@ -437,6 +445,8 @@ gt.pipe(gte.gt_theme_nytimes)
 ### [gt_theme_excel](https://posit-dev.github.io/gt-extras/reference/gt_theme_excel.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_excel
+gt = gt.tab_header(title="Excel Theme")
+
 gt.pipe(gte.gt_theme_excel)
 ```
 {{< include ./_show-last.qmd >}}
@@ -444,6 +454,8 @@ gt.pipe(gte.gt_theme_excel)
 ### [gt_theme_dot_matrix](https://posit-dev.github.io/gt-extras/reference/gt_theme_dot_matrix.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_dot_matrix
+gt = gt.tab_header(title="Dot Matrix Theme")
+
 gt.pipe(gte.gt_theme_dot_matrix)
 ```
 {{< include ./_show-last.qmd >}}
@@ -451,6 +463,8 @@ gt.pipe(gte.gt_theme_dot_matrix)
 ### [gt_theme_dark](https://posit-dev.github.io/gt-extras/reference/gt_theme_dark.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_dark
+gt = gt.tab_header(title="Dark Theme")
+
 gt.pipe(gte.gt_theme_dark)
 ```
 {{< include ./_show-last.qmd >}}
@@ -458,6 +472,8 @@ gt.pipe(gte.gt_theme_dark)
 ### [gt_theme_pff](https://posit-dev.github.io/gt-extras/reference/gt_theme_pff.html){title="Click for reference"}
 ```{python}
 # | label: gt_theme_pff
+gt = gt.tab_header(title="PFF Theme")
+
 gt.pipe(gte.gt_theme_pff)
 ```
 {{< include ./_show-last.qmd >}}


### PR DESCRIPTION
Theme examples are now named.

<img width="468" height="842" alt="Screenshot 2025-07-21 at 1 42 57 PM" src="https://github.com/user-attachments/assets/01d96744-2dc4-489a-8975-79d04c73a938" />